### PR TITLE
added tiny-each-async to benchmarks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -4,6 +4,7 @@ var seriesNoResults = require('./')({ results: false })
 var async = require('async')
 var neo = require('neo-async')
 var bench = require('fastbench')
+var tinyEachAsync = require('tiny-each-async')
 
 function benchFastSeries (done) {
   series(null, [somethingP, somethingP, somethingP], 42, done)
@@ -45,6 +46,10 @@ function benchNeoMapSeries (done) {
   neo.mapSeries([1, 2, 3], somethingP, done)
 }
 
+function benchTinyEachAsync (done) {
+  tinyEachAsync([1, 2, 3], 1, somethingP, done)
+}
+
 var nextDone
 var nextCount
 
@@ -79,6 +84,7 @@ var run = bench([
   benchNeoSeries,
   benchNeoEachSeries,
   benchNeoMapSeries,
+  benchTinyEachAsync,
   benchFastSeries,
   benchFastSeriesNoResults,
   benchFastSeriesEach,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "neo-async": "^1.7.0",
     "pre-commit": "^1.0.6",
     "standard": "^5.4.1",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "tiny-each-async": "^2.0.2"
   },
   "dependencies": {
     "reusify": "^1.0.0",


### PR DESCRIPTION
https://github.com/alessioalex/tiny-each-async with concurrency limit 1 == similar to fastseries, but doesn't aggregate results
