### PR TITLE
Update to turbofan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,29 +3,6 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  legacy:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: ['0.10', '0.12', 4.x, 6.x, 8.x]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install
-        run: |
-          npm install --production && npm install tape
-
-      - name: Run tests
-        run: |
-          npm run unit
-
   test:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,6 @@
 Zero-overhead series function call for node.js.
 Also supports `each` and `map`!
 
-Benchmark for doing 3 calls `setImmediate` 1 million times:
-
-* non-reusable `setImmediate`: 3887ms
-* `async.series`: 5981ms
-* `async.eachSeries`: 5087ms
-* `async.mapSeries`: 5540ms
-* `neoAsync.series`: 4338ms
-* `neoAsync.eachSeries`: 4195ms
-* `neoAsync.mapSeries`: 4237ms
-* `tiny-each-async`: 4575ms
-* `fastseries` with results: 4096ms
-* `fastseries` without results: 4063ms
-* `fastseries` map: 4032ms
-* `fastseries` each: 4168ms
-
-These benchmarks where taken via `bench.js` on node 4.2.2, on a MacBook
-Pro Retina 2014.
-
 If you need zero-overhead parallel function call, check out
 [fastparallel](http://npm.im/fastparallel).
 
@@ -35,10 +17,6 @@ If you need zero-overhead parallel function call, check out
 
 ```js
 var series = require('fastseries')({
-  // this is a function that will be called
-  // when a series completes
-  released: completed,
-
   // if you want the results, then here you are
   results: true
 })
@@ -62,20 +40,12 @@ function something (arg, cb) {
 function done (err, results) {
   console.log('series completed, results:', results)
 }
-
-function completed () {
-  console.log('series completed!')
-}
 ```
 
 ## Example for each and map calls
 
 ```js
 var series = require('fastseries')({
-  // this is a function that will be called
-  // when a series completes
-  released: completed,
-
   // if you want the results, then here you are
   // passing false disables map
   results: true
@@ -100,11 +70,6 @@ function something (arg, cb) {
 function done (err, results) {
   console.log('series completed, results:', results)
 }
-
-function completed () {
-  console.log('series completed!')
-}
-
 ```
 
 ## Caveats
@@ -113,6 +78,27 @@ The `done` function will be called only once, even if more than one error happen
 
 This library works by caching the latest used function, so that running a new series
 does not cause **any memory allocations**.
+
+## Benchmarks
+
+Benchmark for doing 3 calls `setImmediate` 1 million times:
+
+```
+benchSetImmediate*1000000: 2491.637ms
+benchAsyncSeries*1000000: 3112.809ms
+benchAsyncEachSeries*1000000: 2915.850ms
+benchAsyncMapSeries*1000000: 3071.146ms
+benchNeoSeries*1000000: 2651.700ms
+benchNeoEachSeries*1000000: 2649.060ms
+benchNeoMapSeries*1000000: 2638.345ms
+benchTinyEachAsync*1000000: 2741.891ms
+benchFastSeries*1000000: 2571.779ms
+benchFastSeriesNoResults*1000000: 2563.580ms
+benchFastSeriesEach*1000000: 2562.255ms
+benchFastSeriesEachResults*1000000: 2606.948ms
+```
+
+See [bench.js](./bench.js) for mode details.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ does not cause **any memory allocations**.
 Benchmark for doing 3 calls `setImmediate` 1 million times:
 
 ```
-benchSetImmediate*1000000: 2491.637ms
-benchAsyncSeries*1000000: 3112.809ms
-benchAsyncEachSeries*1000000: 2915.850ms
-benchAsyncMapSeries*1000000: 3071.146ms
-benchNeoSeries*1000000: 2651.700ms
-benchNeoEachSeries*1000000: 2649.060ms
-benchNeoMapSeries*1000000: 2638.345ms
-benchTinyEachAsync*1000000: 2741.891ms
-benchFastSeries*1000000: 2571.779ms
-benchFastSeriesNoResults*1000000: 2563.580ms
-benchFastSeriesEach*1000000: 2562.255ms
-benchFastSeriesEachResults*1000000: 2606.948ms
+benchSetImmediate*1000000: 2460.623ms
+benchAsyncSeries*1000000: 3064.569ms
+benchAsyncEachSeries*1000000: 2913.525ms
+benchAsyncMapSeries*1000000: 3020.794ms
+benchNeoSeries*1000000: 2617.064ms
+benchNeoEachSeries*1000000: 2621.672ms
+benchNeoMapSeries*1000000: 2611.294ms
+benchTinyEachAsync*1000000: 2706.457ms
+benchFastSeries*1000000: 2540.653ms
+benchFastSeriesNoResults*1000000: 2538.674ms
+benchFastSeriesEach*1000000: 2534.856ms
+benchFastSeriesEachResults*1000000: 2545.394ms
 ```
 
 Benchmarks taken on Node 12.16.1 on a dedicated server.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ benchFastSeriesEach*1000000: 2562.255ms
 benchFastSeriesEachResults*1000000: 2606.948ms
 ```
 
+Benchmarks taken on Node 12.16.1 on a dedicated server.
+
 See [bench.js](./bench.js) for mode details.
 
 ## License

--- a/bench.js
+++ b/bench.js
@@ -77,14 +77,14 @@ function somethingA (cb) {
 }
 
 var run = bench([
-  // benchSetImmediate,
-  // benchAsyncSeries,
-  // benchAsyncEachSeries,
-  // benchAsyncMapSeries,
-  // benchNeoSeries,
-  // benchNeoEachSeries,
-  // benchNeoMapSeries,
-  // benchTinyEachAsync,
+  benchSetImmediate,
+  benchAsyncSeries,
+  benchAsyncEachSeries,
+  benchAsyncMapSeries,
+  benchNeoSeries,
+  benchNeoEachSeries,
+  benchNeoMapSeries,
+  benchTinyEachAsync,
   benchFastSeries,
   benchFastSeriesNoResults,
   benchFastSeriesEach,

--- a/bench.js
+++ b/bench.js
@@ -77,14 +77,14 @@ function somethingA (cb) {
 }
 
 var run = bench([
-  benchSetImmediate,
-  benchAsyncSeries,
-  benchAsyncEachSeries,
-  benchAsyncMapSeries,
-  benchNeoSeries,
-  benchNeoEachSeries,
-  benchNeoMapSeries,
-  benchTinyEachAsync,
+  // benchSetImmediate,
+  // benchAsyncSeries,
+  // benchAsyncEachSeries,
+  // benchAsyncMapSeries,
+  // benchNeoSeries,
+  // benchNeoEachSeries,
+  // benchNeoMapSeries,
+  // benchTinyEachAsync,
   benchFastSeries,
   benchFastSeriesNoResults,
   benchFastSeriesEach,

--- a/package.json
+++ b/package.json
@@ -39,9 +39,5 @@
     "standard": "^14.3.1",
     "tape": "^4.13.0",
     "tiny-each-async": "^2.0.3"
-  },
-  "dependencies": {
-    "reusify": "^1.0.4",
-    "xtend": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "unit": "tape test.js",
     "unit:report": "nyc --reporter=html --reporter=cobertura --reporter=text tape test.js",
     "unit:cov": "nyc --reporter=lcovonly tape test.js",
+    "cov": "nyc --reporter=text tape test.js",
     "test:report": "npm run lint && npm run unit:report",
     "test": "npm run lint && npm run unit:cov"
   },

--- a/series.js
+++ b/series.js
@@ -50,19 +50,12 @@ function fastseries (options) {
 function noResultEach (each, list, cb) {
   var i = 0
   var length = list.length
-  var makeCall
-
-  if (cb.length === 1) {
-    makeCall = makeCallOne
-  } else {
-    makeCall = makeCallTwo
-  }
 
   release()
 
   function release () {
     if (i < length) {
-      makeCall(each, list[i++], release)
+      makeCallTwo(each, list[i++], release)
     } else {
       cb()
     }
@@ -94,14 +87,6 @@ function noResultList (list, arg, cb) {
 function resultEach (each, list, cb) {
   var i = 0
   var length = list.length
-  var makeCall
-
-  if (cb.length === 1) {
-    makeCall = makeCallOne
-  } else {
-    makeCall = makeCallTwo
-  }
-
   var results = new Array(length)
 
   release(null, null)
@@ -117,7 +102,7 @@ function resultEach (each, list, cb) {
     }
 
     if (i < length) {
-      makeCall(each, list[i++], release)
+      makeCallTwo(each, list[i++], release)
     } else {
       cb(null, results)
     }

--- a/series.js
+++ b/series.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var defaults = {
-  released: nop,
   results: true
 }
 
@@ -19,8 +18,6 @@ function fastseries (options) {
     seriesList = noResultList
   }
 
-  var released = options.released
-
   return series
 
   function series (that, toCall, arg, done) {
@@ -28,9 +25,8 @@ function fastseries (options) {
 
     if (toCall.length === 0) {
       done.call(that)
-      released()
     } else if (toCall.bind) {
-      seriesEach(toCall.bind(that), arg, done, released)
+      seriesEach(toCall.bind(that), arg, done)
     } else {
       var _list
       if (that) {
@@ -42,12 +38,12 @@ function fastseries (options) {
         _list = toCall
       }
 
-      seriesList(_list, arg, done, released)
+      seriesList(_list, arg, done)
     }
   }
 }
 
-function noResultEach (each, list, cb, released) {
+function noResultEach (each, list, cb) {
   var i = 0
   var length = list.length
   var makeCall
@@ -65,12 +61,11 @@ function noResultEach (each, list, cb, released) {
       makeCall(each, list[i++], release)
     } else {
       cb()
-      released()
     }
   }
 }
 
-function noResultList (list, arg, cb, released) {
+function noResultList (list, arg, cb) {
   var i = 0
   var length = list.length
   var makeCall
@@ -88,12 +83,11 @@ function noResultList (list, arg, cb, released) {
       makeCall(list[i++], arg, release)
     } else {
       cb()
-      released()
     }
   }
 }
 
-function resultEach (each, list, cb, released) {
+function resultEach (each, list, cb) {
   var i = 0
   var length = list.length
   var makeCall
@@ -111,7 +105,6 @@ function resultEach (each, list, cb, released) {
   function release (err, result) {
     if (err) {
       cb(err)
-      released()
       return
     }
 
@@ -123,12 +116,11 @@ function resultEach (each, list, cb, released) {
       makeCall(each, list[i++], release)
     } else {
       cb(null, results)
-      released()
     }
   }
 }
 
-function resultList (list, arg, cb, released) {
+function resultList (list, arg, cb) {
   var i = 0
   var length = list.length
   var makeCall
@@ -146,7 +138,6 @@ function resultList (list, arg, cb, released) {
   function release (err, result) {
     if (err) {
       cb(err)
-      released()
       return
     }
 
@@ -158,7 +149,6 @@ function resultList (list, arg, cb, released) {
       makeCall(list[i++], arg, release)
     } else {
       cb(null, results)
-      released()
     }
   }
 }

--- a/series.js
+++ b/series.js
@@ -1,124 +1,174 @@
 'use strict'
 
-var xtend = require('xtend')
-var reusify = require('reusify')
 var defaults = {
   released: nop,
   results: true
 }
 
 function fastseries (options) {
-  options = xtend(defaults, options)
+  options = Object.assign({}, defaults, options)
+
+  var seriesEach
+  var seriesList
+
+  if (options.results) {
+    seriesEach = resultEach
+    seriesList = resultList
+  } else {
+    seriesEach = noResultEach
+    seriesList = noResultList
+  }
 
   var released = options.released
-  var queue = reusify(options.results ? ResultsHolder : NoResultsHolder)
 
   return series
 
   function series (that, toCall, arg, done) {
-    var holder = queue.get()
-    holder._released = release
-
-    done = done || nop
+    done = (done || nop).bind(that)
 
     if (toCall.length === 0) {
       done.call(that)
-      release(holder)
+      released()
+    } else if (toCall.bind) {
+      seriesEach(toCall.bind(that), arg, done, released)
     } else {
-      holder._callback = done
-
-      if (toCall.call) {
-        holder._list = arg
-        holder._each = toCall
+      var _list
+      if (that) {
+        _list = new Array(toCall.length)
+        for (var i = 0; i < toCall.length; i++) {
+          _list[i] = toCall[i].bind(that)
+        }
       } else {
-        holder._list = toCall
-        holder._arg = arg
+        _list = toCall
       }
 
-      holder._callThat = that
-      holder.release()
+      seriesList(_list, arg, done, released)
     }
   }
-
-  function release (holder) {
-    queue.release(holder)
-    released()
-  }
 }
 
-function reset () {
-  this._list = null
-  this._arg = null
-  this._callThat = null
-  this._callback = nop
-  this._each = null
-}
-
-function NoResultsHolder () {
-  reset.call(this)
-  this.next = null
-  this._released = null
-
-  var that = this
+function noResultEach (each, list, cb, released) {
   var i = 0
-  this.release = function () {
-    if (i < that._list.length) {
-      if (that._each) {
-        makeCall(that._callThat, that._each, that._list[i++], that.release)
-      } else {
-        makeCall(that._callThat, that._list[i++], that._arg, that.release)
-      }
-    } else {
-      that._callback.call(that._callThat)
-      reset.call(that)
-      i = 0
-      that._released(that)
-    }
-  }
-}
+  var length = list.length
+  var makeCall
 
-function ResultsHolder (_release) {
-  reset.call(this)
-
-  this._results = []
-  this.next = null
-  this._released = null
-
-  var that = this
-  var i = 0
-  this.release = function (err, result) {
-    if (i !== 0) that._results[i - 1] = result
-
-    if (!err && i < that._list.length) {
-      if (that._each) {
-        makeCall(that._callThat, that._each, that._list[i++], that.release)
-      } else {
-        makeCall(that._callThat, that._list[i++], that._arg, that.release)
-      }
-    } else {
-      that._callback.call(that._callThat, err, that._results)
-      reset.call(that)
-      that._results = []
-      i = 0
-      that._released(that)
-    }
-  }
-}
-
-function makeCall (that, cb, arg, release) {
-  if (that) {
-    if (cb.length === 1) {
-      cb.call(that, release)
-    } else {
-      cb.call(that, arg, release)
-    }
+  if (cb.length === 1) {
+    makeCall = makeCallOne
   } else {
-    if (cb.length === 1) {
-      cb(release)
+    makeCall = makeCallTwo
+  }
+
+  release()
+
+  function release () {
+    if (i < length) {
+      makeCall(each, list[i++], release)
     } else {
-      cb(arg, release)
+      cb()
+      released()
     }
   }
+}
+
+function noResultList (list, arg, cb, released) {
+  var i = 0
+  var length = list.length
+  var makeCall
+
+  if (list[0].length === 1) {
+    makeCall = makeCallOne
+  } else {
+    makeCall = makeCallTwo
+  }
+
+  release()
+
+  function release () {
+    if (i < length) {
+      makeCall(list[i++], arg, release)
+    } else {
+      cb()
+      released()
+    }
+  }
+}
+
+function resultEach (each, list, cb, released) {
+  var i = 0
+  var length = list.length
+  var makeCall
+
+  if (cb.length === 1) {
+    makeCall = makeCallOne
+  } else {
+    makeCall = makeCallTwo
+  }
+
+  var results = new Array(length)
+
+  release(null, null)
+
+  function release (err, result) {
+    if (err) {
+      cb(err)
+      released()
+      return
+    }
+
+    if (i > 0) {
+      results[i - 1] = result
+    }
+
+    if (i < length) {
+      makeCall(each, list[i++], release)
+    } else {
+      cb(null, results)
+      released()
+    }
+  }
+}
+
+function resultList (list, arg, cb, released) {
+  var i = 0
+  var length = list.length
+  var makeCall
+
+  if (list[0].length === 1) {
+    makeCall = makeCallOne
+  } else {
+    makeCall = makeCallTwo
+  }
+
+  var results = new Array(length)
+
+  release()
+
+  function release (err, result) {
+    if (err) {
+      cb(err)
+      released()
+      return
+    }
+
+    if (i > 0) {
+      results[i - 1] = result
+    }
+
+    if (i < length) {
+      makeCall(list[i++], arg, release)
+    } else {
+      cb(null, results)
+      released()
+    }
+  }
+}
+
+function makeCallOne (cb, arg, release) {
+  cb(release)
+}
+
+function makeCallTwo (cb, arg, release) {
+  cb(arg, release)
 }
 
 function nop () { }

--- a/series.js
+++ b/series.js
@@ -26,12 +26,16 @@ function fastseries (options) {
     if (toCall.length === 0) {
       done.call(that)
     } else if (toCall.bind) {
-      seriesEach(toCall.bind(that), arg, done)
+      if (that) {
+        toCall = toCall.bind(that)
+      }
+      seriesEach(toCall, arg, done)
     } else {
       var _list
       if (that) {
-        _list = new Array(toCall.length)
-        for (var i = 0; i < toCall.length; i++) {
+        var length = toCall.length
+        _list = new Array(length)
+        for (var i = 0; i < length; i++) {
           _list[i] = toCall[i].bind(that)
         }
       } else {
@@ -133,7 +137,7 @@ function resultList (list, arg, cb) {
 
   var results = new Array(length)
 
-  release()
+  release(null, null)
 
   function release (err, result) {
     if (err) {

--- a/test.js
+++ b/test.js
@@ -2,11 +2,9 @@ var test = require('tape')
 var series = require('./')
 
 test('basically works', function (t) {
-  t.plan(8)
+  t.plan(7)
 
-  var instance = series({
-    released: released
-  })
+  var instance = series()
   var count = 0
   var obj = {}
 
@@ -25,18 +23,12 @@ test('basically works', function (t) {
       })
     }
   }
-
-  function released () {
-    t.pass()
-  }
 })
 
 test('accumulates results', function (t) {
-  t.plan(8)
+  t.plan(7)
 
-  var instance = series({
-    released: released
-  })
+  var instance = series()
   var count = 0
   var obj = {}
 
@@ -54,18 +46,12 @@ test('accumulates results', function (t) {
       cb(null, count)
     })
   }
-
-  function released () {
-    t.pass()
-  }
 })
 
 test('fowards errs', function (t) {
-  t.plan(4)
+  t.plan(3)
 
-  var instance = series({
-    released: released
-  })
+  var instance = series()
   var count = 0
   var obj = {}
 
@@ -88,17 +74,12 @@ test('fowards errs', function (t) {
       cb(new Error('this is an err!'))
     })
   }
-
-  function released () {
-    t.pass()
-  }
 })
 
 test('does not forward errors or result with results:false flag', function (t) {
-  t.plan(8)
+  t.plan(7)
 
   var instance = series({
-    released: released,
     results: false
   })
   var count = 0
@@ -118,35 +99,23 @@ test('does not forward errors or result with results:false flag', function (t) {
       cb()
     })
   }
-
-  function released () {
-    t.pass()
-  }
 })
 
-test('should call done and released if an empty is passed', function (t) {
-  t.plan(2)
+test('should call done iff an empty is passed', function (t) {
+  t.plan(1)
 
-  var instance = series({
-    released: released
-  })
+  var instance = series()
   var obj = {}
 
   instance(obj, [], 42, function done () {
     t.pass()
   })
-
-  function released () {
-    t.pass()
-  }
 })
 
 test('each support', function (t) {
-  t.plan(8)
+  t.plan(7)
 
-  var instance = series({
-    released: released
-  })
+  var instance = series()
   var count = 0
   var obj = {}
   var args = [1, 2, 3]
@@ -163,10 +132,6 @@ test('each support', function (t) {
       count++
       cb()
     })
-  }
-
-  function released () {
-    t.pass()
   }
 })
 


### PR DESCRIPTION
This is an update to make fastseries shine on Node 12.x. It drops two unneeded dependencies.

It drops the `released` callback, as it was seldomly used.

From an implementation point of view, this is a semver-major rewrite that moves away from the concept of an holder object to just allocate one closure for each loop to hold the state.